### PR TITLE
Assert that taskIndex >= -1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,11 +48,10 @@ test {
 }
 
 application {
-    mainClass.set("ezra.Ezra")
+    mainClass.set("gui.Launcher")
 }
 
 shadowJar {
-    archiveBaseName = "ezra"
     archiveFileName = 'ezra.jar'
     archiveClassifier = null
     dependsOn("distZip", "distTar")
@@ -60,4 +59,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/ezra/TaskList.java
+++ b/src/main/java/ezra/TaskList.java
@@ -94,6 +94,8 @@ public class TaskList {
         // Delete task numbers from largest to smallest so that there are no changes in task number after each deletion
         for (int i = sortedTaskNumbers.length - 1; i >= 0; i--) {
             int taskIndex = sortedTaskNumbers[i] - 1;
+            assert taskIndex >= -1: "sortedTaskNumbers[i] >= 0 so taskIndex >= -1";
+
             // Check for invalid taskIndex
             if (taskIndex < 0 || taskIndex >= this.tasks.size()) {
                 invalidTaskNumbers.append(String.format("%d is an invalid task number\n", sortedTaskNumbers[i]));
@@ -155,6 +157,8 @@ public class TaskList {
 
         for (String taskNumber : taskNumbers) {
             int taskIndex = Integer.parseInt(taskNumber) - 1;
+            assert taskIndex >= -1: "Integer.parseInt(taskNumber) >= 0 so taskIndex >= -1";
+
             // Check for invalid taskIndex
             if (taskIndex < 0 || taskIndex >= this.tasks.size()) {
                 invalidTaskNumbers.append(String.format("%d is an invalid task number\n", taskIndex + 1));
@@ -192,6 +196,8 @@ public class TaskList {
 
         for (String taskNumber : taskNumbers) {
             int taskIndex = Integer.parseInt(taskNumber) - 1;
+            assert taskIndex >= -1: "Integer.parseInt(taskNumber) >= 0 so taskIndex >= -1";
+
             // Check for invalid taskIndex
             if (taskIndex < 0 || taskIndex >= this.tasks.size()) {
                 invalidTaskNumbers.append(String.format("%d is an invalid task number\n", taskIndex + 1));
@@ -230,6 +236,7 @@ public class TaskList {
                 matchingTasks.add(i);
             }
         }
+
         if (matchingTasks.isEmpty()) {
             message.append("There are no matching tasks in your list:");
         } else {


### PR DESCRIPTION
parseMark, parseUnmark and parseDelete ensures that only digits are allowed after the command so the taskNumber is at least 0. taskIndex is 1 less than taskNumber so taskIndex is at least -1.